### PR TITLE
Add support for custom path matching

### DIFF
--- a/Sources/Glide/Classes/Routing/PathBuilder.swift
+++ b/Sources/Glide/Classes/Routing/PathBuilder.swift
@@ -1,6 +1,13 @@
 import Foundation
 
-struct PathBuilder {
+public protocol PathMatching {
+  func match(_ url: String) -> (
+    isMatching: Bool,
+    parameters: Parameters
+  )
+}
+
+struct PathBuilder: PathMatching {
   var segments = [PathSegmentDescriptor]()
 
   func match(_ url: String) -> (

--- a/Sources/Glide/Classes/Routing/Router.swift
+++ b/Sources/Glide/Classes/Routing/Router.swift
@@ -41,6 +41,7 @@ extension Router {
 
 // MARK: - HTTP Methods
 extension Router {
+  // MARK: Get
   public func get(
     _ pathLiteral: String = "",
     handler: @escaping HTTPHandler
@@ -59,6 +60,16 @@ extension Router {
     )
   }
 
+  public func get(
+    _ pathMatcher: PathMatching,
+    handler: @escaping HTTPHandler
+  ) {
+    use(
+      generate(with: pathMatcher, and: handler)
+    )
+  }
+
+  // MARK: Post
   public func post(
     _ pathLiteral: String = "",
     handler: @escaping HTTPHandler
@@ -77,6 +88,16 @@ extension Router {
     )
   }
 
+  public func post(
+    _ pathMatcher: PathMatching,
+    handler: @escaping HTTPHandler
+  ) {
+    use(
+      generate(.POST, with: pathMatcher, and: handler)
+    )
+  }
+
+  // MARK: Put
   public func put(
     _ pathLiteral: String = "",
     handler: @escaping HTTPHandler
@@ -95,6 +116,16 @@ extension Router {
     )
   }
 
+  public func put(
+    _ pathMatcher: PathMatching,
+    handler: @escaping HTTPHandler
+  ) {
+    use(
+      generate(.PUT, with: pathMatcher, and: handler)
+    )
+  }
+
+  // MARK: Patch
   public func patch(
     _ pathLiteral: String = "",
     handler: @escaping HTTPHandler
@@ -113,6 +144,16 @@ extension Router {
     )
   }
 
+  public func patch(
+    _ pathMatcher: PathMatching,
+    handler: @escaping HTTPHandler
+  ) {
+    use(
+      generate(.PATCH, with: pathMatcher, and: handler)
+    )
+  }
+
+  // MARK: Delete
   public func delete(
     _ pathLiteral: String = "",
     handler: @escaping HTTPHandler
@@ -131,6 +172,16 @@ extension Router {
     )
   }
 
+  public func delete(
+    _ pathMatcher: PathMatching,
+    handler: @escaping HTTPHandler
+  ) {
+    use(
+      generate(.DELETE, with: pathMatcher, and: handler)
+    )
+  }
+
+  // MARK: Private Members
   private func generate(
     _ method: HTTPMethod = .GET,
     with pathLiteral: String = "",
@@ -149,7 +200,7 @@ extension Router {
 
   private func generate(
     _ method: HTTPMethod = .GET,
-    with builder: PathBuilder,
+    with builder: PathMatching,
     and handler: @escaping HTTPHandler
   ) -> Middleware {
     { request, response, nextHandler in
@@ -165,7 +216,6 @@ extension Router {
       }
     }
   }
-
 }
 
 extension Router {

--- a/Sources/Sample/main.swift
+++ b/Sources/Sample/main.swift
@@ -49,7 +49,7 @@ app.use(errorLogger, { errors, _, _ in
 })
 
 app.use { _, _, _ in
-throw CustomError.missingUser
+  throw CustomError.missingUser
 }
 
 app.get("/throw") { _, _ in

--- a/Tests/GlideTests/RoutingTests.swift
+++ b/Tests/GlideTests/RoutingTests.swift
@@ -159,4 +159,31 @@ final class RoutingTests: GlideTests {
 
     wait(for: [expectation], timeout: 5)
   }
+
+  func testCustomerMatcher() throws {
+    struct MyCustomerMatcher: PathMatching {
+      func match(_ url: String) -> (isMatching: Bool, parameters: Parameters) {
+        return (true, Parameters())
+      }
+    }
+
+    let expectation = XCTestExpectation()
+
+    performHTTPTest { app, client in
+      app.get(MyCustomerMatcher()) { request, response in
+        response.send("Matching successful")
+        expectation.fulfill()
+      }
+
+      let request = try HTTPClient.Request(
+        url: "http://localhost:\(testPort)/foo/bar",
+        method: .GET,
+        headers: .init()
+      )
+
+      _ = try client.execute(request: request).wait()
+    }
+
+    wait(for: [expectation], timeout: 5)
+  }
 }


### PR DESCRIPTION
This PR adds support for custom path matching. Example:

```swift
struct MyCustomMatcher: PathMatching {
  func match(_ url: String) -> (isMatching: Bool, parameters: Parameters) {
    return (true, Parameters())
  }
}

app.get(MyCustomMatcher()) { request, response in
  response.send("Path matched successfully")
}
```