### PR TITLE
Returning middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,11 +122,9 @@ For example, if you want your app to return a list of todos when the user visits
 app.get("/todos") { request, response in
   let todos = ... // Get a list of todos from a database, file, remote server, etc.
   
-  response.json(todos)
+  return .json(todos)
 }
 ```
-
-Notice how the `get()`  middleware generator doesn't require you to worry about the next handler closure. This also implies that you have to finalize the response and send it back, in this case as a JOSN response using the `response.json()` helper.
 
 #### Parameters & Queries
 
@@ -141,7 +139,7 @@ app.get("/todos/\("id", as: Int.self)") { request, response in
   let id: Int = request.pathParameters.id 
   
   if let todo = findTodo(id) {
-    response.json(todo)
+    return .json(todo)
   } else {
     throw CustomError.todoNotFound  
   }
@@ -156,7 +154,7 @@ app.get("/todos") { request, response in
   let sortOrder = request.queryParameters.sortOrder ?? "DESC"
   let sortedTodos = ... // Get a list of todos with the sort order.
   
-  response.json(sortedTodos)
+  return .json(sortedTodos)
 }
 ```
 and in the shell:

--- a/Sources/Glide/Classes/App.swift
+++ b/Sources/Glide/Classes/App.swift
@@ -54,7 +54,7 @@ public final class Application: Router {
         try serverChannel!.closeFuture.wait()
       }
     } catch {
-      fatalError("Failed to start server: \(error.localizedDescription)")
+      fatalError("Failed to start server: \(error)")
     }
   }
 

--- a/Sources/Glide/Classes/Response.swift
+++ b/Sources/Glide/Classes/Response.swift
@@ -94,15 +94,7 @@ public extension Response {
     }
   }
 
-  func json<T: Encodable>(_ model: T) {
-    let data : Data
-
-    do {
-      data = try JSONEncoder().encode(model)
-    } catch {
-      return handleError(error)
-    }
-
+  func send(_ data: Data) {
     self["Content-Type"] = "application/json"
     self["Content-Length"] = "\(data.count)"
 
@@ -116,5 +108,16 @@ public extension Response {
     channel.writeAndFlush(bodypart)
       .recover(handleError)
       .whenSuccess(end)
+  }
+
+  func send<T: Encodable>(_ model: T) {
+    let data : Data
+
+    do {
+      data = try JSONEncoder().encode(model)
+      send(data)
+    } catch {
+      return handleError(error)
+    }
   }
 }

--- a/Sources/Glide/Errors/ErrorHandler.swift
+++ b/Sources/Glide/Errors/ErrorHandler.swift
@@ -20,7 +20,7 @@ let errorHandler: ErrorHandler = { errors, request, response in
     errorDescription = "Unknown internal error."
   }
 
-  response.json(
+  response.send(
     Router.ErrorResponse(error: errorDescription)
   )
 }

--- a/Sources/Glide/Helpers/Middleware.swift
+++ b/Sources/Glide/Helpers/Middleware.swift
@@ -12,16 +12,7 @@ public enum MiddlewareResult {
   case send(String)
   case data(Data)
   case file(String)
-
-  public var isFinal: Bool {
-    switch self {
-    case .next:
-      return true
-    default:
-      return false
-    }
-  }
-
+  
   public static func json<T: Encodable>(_ model: T) -> Self {
     if let data = try? JSONEncoder().encode(model) {
       return .data(data)

--- a/Sources/Glide/Helpers/Middleware.swift
+++ b/Sources/Glide/Helpers/Middleware.swift
@@ -6,26 +6,40 @@ import Glibc
 import Darwin.C
 #endif
 
-public typealias Handler = () -> Void
-public typealias HTTPHandler = (Request, Response) throws -> Void
-public typealias ErrorHandler = ([Error], Request, Response) -> Void
 
-public typealias Middleware = (
-  _ request: Request,
-  _ response: Response,
-  _ next: @escaping () -> Void
-) throws -> Void
+public enum MiddlewareResult {
+  case next
+  case send(String)
+  case data(Data)
+  case file(String)
 
-public func passthrough(_ perform: @escaping HTTPHandler) -> Middleware {
-  return { request, response, nextHandler in
-    try perform(request, response)
-    nextHandler()
+  public var isFinal: Bool {
+    switch self {
+    case .next:
+      return true
+    default:
+      return false
+    }
+  }
+
+  public static func json<T: Encodable>(_ model: T) -> Self {
+    if let data = try? JSONEncoder().encode(model) {
+      return .data(data)
+    } else {
+      return .next
+    }
   }
 }
 
-public func finalize(_ perform: @escaping HTTPHandler) -> Middleware {
-  return { request, response, _ in
+public typealias Handler = () -> Void
+public typealias Middleware = (Request, Response) throws -> MiddlewareResult
+public typealias HTTPHandler = (Request, Response) throws -> Void
+public typealias ErrorHandler = ([Error], Request, Response) -> Void
+
+public func passthrough(_ perform: @escaping HTTPHandler) -> Middleware {
+  return { request, response in
     try perform(request, response)
+    return .next
   }
 }
 
@@ -82,21 +96,21 @@ public func staticFileHandler(_
 
   return Router.generate(.GET, with: path) { request, response in
     let filePath = request.pathParameters.wildcards.joined(separator: "/")
-    try response.file(at: "\(assetPath)/\(filePath)", for: request)
+    return .file("\(assetPath)/\(filePath)")
   }
 }
 
 public func corsHandler(allowOrigin origin: String) -> Middleware {
-  { request, response, nextHandler in
+  { request, response in
     response["Access-Control-Allow-Origin"] = origin
     response["Access-Control-Allow-Headers"] = "Accept, Content-Type"
     response["Access-Control-Allow-Methods"] = "GET, OPTIONS"
 
     if request.header.method == .OPTIONS {
       response["Allow"] = "GET, OPTIONS"
-      response.send("")
+      return .send("")
     } else {
-      nextHandler()
+      return .next
     }
   }
 }

--- a/Sources/Sample/main.swift
+++ b/Sources/Sample/main.swift
@@ -50,7 +50,7 @@ app.use(errorLogger, { errors, _, _ in
   print(errors.count, "error(s) encountered.")
 })
 
-app.use { _, _, _ in
+app.use { _, _ in
   throw CustomError.missingUser
 }
 
@@ -63,7 +63,7 @@ app.get("/abort") { _, _ in
 }
 
 app.get("/hello/\("name")") { request, response in
-  response.send("Hello, \(request.pathParameters.name ?? "world")!")
+  .send("Hello, \(request.pathParameters.name ?? "world")!")
 }
 
 app.get("/users/\("id", as: Int.self)") { request, response in
@@ -71,7 +71,7 @@ app.get("/users/\("id", as: Int.self)") { request, response in
     User(id: id)
   }
 
-  response.json(find(request.pathParameters.id ?? 0))
+  return .json(find(request.pathParameters.id ?? 0))
 }
 
 app.post("/post") { request, response in
@@ -81,10 +81,10 @@ app.post("/post") { request, response in
 
   do {
     let user = try JSONDecoder().decode(User.self, from: data)
-    response.send("\(user.name)")
+    return .send("\(user.name)")
   } catch let error as DecodingError {
     throw error
   }
 }
 
-app.listen(1337)
+try app.listen(1337)

--- a/Tests/GlideTests/ErrorHandlerTests.swift
+++ b/Tests/GlideTests/ErrorHandlerTests.swift
@@ -85,8 +85,8 @@ final class ErrorHandlerTests: GlideTests {
         throw CustomAbortError.someError
       }
 
-      app.use { _, response, _ in
-        response.send("Success")
+      app.use { _, _ in
+        return .send("Success")
       }
 
       let request = try HTTPClient.Request(

--- a/Tests/GlideTests/GlideTests.swift
+++ b/Tests/GlideTests/GlideTests.swift
@@ -34,8 +34,8 @@ class AppTests: GlideTests {
     let expectation = XCTestExpectation()
 
     performHTTPTest { app, client in
-      app.get("/ping") { request, response in
-        response.send("pong")
+      app.get("/ping") { _, _ in
+        return .send("pong")
       }
 
       let request = try HTTPClient.Request(

--- a/Tests/GlideTests/JSONTests.swift
+++ b/Tests/GlideTests/JSONTests.swift
@@ -1,0 +1,53 @@
+import Foundation
+import NIO
+import NIOHTTP1
+import AsyncHTTPClient
+import XCTest
+@testable import Glide
+
+final class JSONTests: GlideTests {
+  struct User: Codable {
+    var id: Int
+    var name: String = "user"
+    var password: String = "password"
+  }
+
+  func testJSONResponse() throws {
+    let expectation = XCTestExpectation()
+
+    performHTTPTest { app, client in
+      app.use(
+        consoleLogger
+      )
+
+      app.get("/users/\("id", as: Int.self)") { request, response in
+        func find(_ id: Int) -> User {
+          User(id: id)
+        }
+
+        return .json(find(request.pathParameters.id ?? 0))
+      }
+
+      let request = try HTTPClient.Request(
+        url: "http://localhost:\(testPort)/users/8",
+        method: .GET,
+        headers: .init()
+      )
+
+      let response = try client.execute(request: request).wait()
+      var buffer = response.body ?? ByteBufferAllocator().buffer(capacity: 0)
+      let responseContent = buffer.readData(length: buffer.readableBytes)
+
+      XCTAssertNotNil(responseContent)
+
+      let user = try? JSONDecoder().decode(User.self, from: responseContent!)
+      XCTAssertNotNil(user)
+      XCTAssertEqual(user?.id, 8)
+      XCTAssertEqual(user?.name, "user")
+
+      expectation.fulfill()
+    }
+
+    wait(for: [expectation], timeout: 5)
+  }
+}

--- a/Tests/GlideTests/ParameterTests.swift
+++ b/Tests/GlideTests/ParameterTests.swift
@@ -11,11 +11,12 @@ final class ParameterTests: GlideTests {
 
     performHTTPTest { app, client in
       app.get("/query") { request, response in
-        response.send(request.queryParameters.foo ?? "")
 
         XCTAssertEqual(request.queryParameters["foo"]?.asString(), "bar")
         XCTAssertEqual(request.queryParameters.baz, "qux")
         expectation.fulfill()
+        
+        return .send(request.queryParameters.foo ?? "")
       }
 
       let request = try HTTPClient.Request(
@@ -35,8 +36,6 @@ final class ParameterTests: GlideTests {
 
     performHTTPTest { app, client in
       app.get("/query") { request, response in
-        response.send(request.queryParameters.foo ?? "")
-
         XCTAssertEqual(request.queryParameters["foo"]?.asInt(), 12)
         XCTAssertEqual(request.queryParameters.foo, 12)
 
@@ -50,6 +49,8 @@ final class ParameterTests: GlideTests {
         XCTAssertEqual(request.queryParameters.thud, true)
 
         expectation.fulfill()
+
+        return .send(request.queryParameters.foo ?? "")
       }
 
       let request = try HTTPClient.Request(
@@ -69,7 +70,6 @@ final class ParameterTests: GlideTests {
 
     performHTTPTest { app, client in
       app.get("/query") { request, response in
-        response.send(request.queryParameters.foo ?? "")
 
         XCTAssertEqual(request.queryParameters["foo"]?.asBool(), true)
         XCTAssertTrue(request.queryParameters.foo ?? false)
@@ -80,6 +80,8 @@ final class ParameterTests: GlideTests {
         XCTAssertNotEqual(request.queryParameters.bar, false)
 
         expectation.fulfill()
+
+        return .send(request.queryParameters.foo ?? "")
       }
 
       let request = try HTTPClient.Request(

--- a/Tests/GlideTests/RoutingTests.swift
+++ b/Tests/GlideTests/RoutingTests.swift
@@ -11,11 +11,12 @@ final class RoutingTests: GlideTests {
 
     performHTTPTest { app, client in
       app.get("hello/\("foo")/\("bar", as: Int.self)") { request, response in
-        response.send(request.pathParameters.foo ?? "")
 
         XCTAssertEqual(request.pathParameters.foo, "test")
         XCTAssertEqual(request.pathParameters.bar, 58)
         expectation.fulfill()
+
+        return .send(request.pathParameters.foo ?? "")
       }
 
       let request = try HTTPClient.Request(
@@ -35,12 +36,13 @@ final class RoutingTests: GlideTests {
 
     performHTTPTest { app, client in
       app.get("/hello/\("foo")/\("bar")/baz/\("qux", as: Int.self)/") { request, response in
-        response.send(request.pathParameters.foo ?? "")
 
         XCTAssertEqual(request.pathParameters.foo, "test")
         XCTAssertEqual(request.pathParameters.bar, "glide")
         XCTAssertEqual(request.pathParameters.qux, 58)
         expectation.fulfill()
+
+        return .send(request.pathParameters.foo ?? "")
       }
 
       let request = try HTTPClient.Request(
@@ -60,15 +62,15 @@ final class RoutingTests: GlideTests {
 
     performHTTPTest { app, client in
       app.get("/hello/{foo}/{bar:string}/baz/{qux:int}/") { request, response in
-        response.send(request.pathParameters.foo ?? "")
+        return .send(request.pathParameters.foo ?? "")
       }
 
       app.get("/hello") { request, response in
-        response.send(request.pathParameters.foo ?? "")
+        return .send(request.pathParameters.foo ?? "")
       }
 
       app.get("/help") { request, response in
-        response.send(request.pathParameters.foo ?? "")
+        return .send(request.pathParameters.foo ?? "")
       }
 
       let request = try HTTPClient.Request(
@@ -97,12 +99,13 @@ final class RoutingTests: GlideTests {
 
     performHTTPTest { app, client in
       app.get("/hello/\(wildcard: .one)/bar/\(wildcard: .one)/baz") { request, response in
-        response.send(request.pathParameters.foo ?? "")
         XCTAssertEqual(request.pathParameters.wildcards.count, 2)
         XCTAssertEqual(request.pathParameters.wildcards[0], "foo")
         XCTAssertEqual(request.pathParameters.wildcards[1], "qux")
 
         expectation.fulfill()
+        
+        return .send(request.pathParameters.foo ?? "")
       }
 
       let request = try HTTPClient.Request(
@@ -122,12 +125,13 @@ final class RoutingTests: GlideTests {
 
     performHTTPTest { app, client in
       app.get("hello/\("param")/\(wildcard: .all)/\("never")") { request, response in
-        response.send(request.pathParameters.foo ?? "")
         XCTAssertEqual(request.pathParameters.param, "foo")
         XCTAssertNil(request.pathParameters["never"]?.asString())
         XCTAssertTrue(request.pathParameters.wildcards.contains("baz"))
         XCTAssertEqual(request.pathParameters.wildcards, ["bar", "baz", "qux"])
         expectation.fulfill()
+
+        return .send(request.pathParameters.foo ?? "")
       }
 
       let request = try HTTPClient.Request(
@@ -153,8 +157,9 @@ final class RoutingTests: GlideTests {
 
     performHTTPTest { app, client in
       app.get(MyCustomParser()) { request, response in
-        response.send("Matching successful")
         expectation.fulfill()
+
+        return .send("Matching successful")
       }
 
       let request = try HTTPClient.Request(


### PR DESCRIPTION
This PR aims to make working with custom middleware a little less error-prone. Thanks to @jnutting for the feedback and pitch.

Before this PR, it was left for the developer to remember to either call `next()` or finalize the response. These changes add a requirement for middleware to return a result, which will put the compiler to work and help avoid human-error.